### PR TITLE
Qa

### DIFF
--- a/app/assets/javascripts/til.js
+++ b/app/assets/javascripts/til.js
@@ -4,6 +4,11 @@ $(function () {
     $(this).fadeOut(200);
   });
 
+  $('.js-nolike').on('click',
+    function (e) {
+    e.preventDefault();
+  });
+
   $('.site_nav__search, .site_nav__about').on(
     'click',
     '.site_nav__link',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,11 +5,16 @@ class ApplicationController < ActionController::Base
   before_action :set_cache_header
 
   helper_method :editable?
+  helper_method :likeable?
 
   private
 
   def editable?(post)
     current_developer && (current_developer == post.developer || current_developer.admin?)
+  end
+
+  def likeable?(post)
+    current_developer && (current_developer != post.developer)
   end
 
   def require_developer

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,6 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update]
   before_action :require_developer, except: %i[index show like unlike]
   before_action :authorize_developer, only: %i[edit update]
-  before_action :prevent_self_like, only: %i[like unlike]
 
   def preview
     render layout: false
@@ -68,6 +67,8 @@ class PostsController < ApplicationController
 
   def like
     post = Post.find_by(slug: params[:slug])
+    return unless current_developer && (current_developer != post.developer)
+
     respond_to do |format|
       if post.increment_likes
         format.json { render json: { likes: post.likes } }
@@ -95,10 +96,6 @@ class PostsController < ApplicationController
   end
 
   private
-
-  def prevent_self_like
-    return if current_developer && current_developer == post.developer
-  end
 
   def process_post
     if params[:published]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,6 +4,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update]
   before_action :require_developer, except: %i[index show like unlike]
   before_action :authorize_developer, only: %i[edit update]
+  before_action :no_self_like, only: %i[like unlike]
 
   def preview
     render layout: false
@@ -67,8 +68,6 @@ class PostsController < ApplicationController
 
   def like
     post = Post.find_by(slug: params[:slug])
-    return unless current_developer && (current_developer != post.developer)
-
     respond_to do |format|
       if post.increment_likes
         format.json { render json: { likes: post.likes } }
@@ -132,6 +131,11 @@ class PostsController < ApplicationController
 
   def authorize_developer
     redirect_to root_path, alert: 'You can only edit your own posts' unless editable?(@post)
+  end
+
+  def no_self_like
+    post = Post.find_by(slug: params[:slug])
+    redirect_to root_path unless current_developer && (current_developer != post.developer)
   end
 
   def valid_url?

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -26,7 +26,7 @@
             = link_to "edit", [:edit, post], class: "post__edit-link"
         - unless post.draft?
           %li
-            = link_to post_path(post), class: "js-like-action post__like-link", id: post.slug do
+            = link_to post_path(post), :class => (likeable?(post) ? 'js-like-action post__like-link' : 'js-nolike post__like-link'), id: post.slug do
               %span.post__like-count= post.likes
               %span.post__like-label likes
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## Quick Info
Prevents developers from liking posts they created

## What does this change?
Add controller before_action for likes and unlike
Allow harmony to parse ES6
Prevent not signed in users from liking or unliking a post
Change post view to have different classes if current_dev is the post author
Use jquery to prevent the default behavior of the button for not signed in users

## Why are you changing that?
To have a better experience

## How do you manually test this?
Like some posts! 

## Screenshots