### PR TITLE
Sitemap generator

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,0 +1,8 @@
+class SitemapController < ApplicationController
+  def show
+    @posts = Post.published_and_ordered
+    respond_to do |format|
+      format.xml
+    end
+  end
+end

--- a/app/views/sitemap/show.xml.builder
+++ b/app/views/sitemap/show.xml.builder
@@ -1,0 +1,12 @@
+xml.instruct! :xml, :version=>"1.0"
+xml.tag! 'urlset', 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9', 'xmlns:image' => 'http://www.google.com/schemas/sitemap-image/1.1', 'xmlns:video' => 'http://www.google.com/schemas/sitemap-video/1.1' do
+  xml.url do
+    xml.loc root_url
+  end
+  @posts.each do |post|
+    xml.url do
+      xml.loc post_url(post)
+      xml.lastmod post.updated_at.strftime('%Y-%m-%d')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get '/auth/failure' => 'sessions#failure'
 
   root to: 'posts#index'
+  resource :sitemap, controller: 'sitemap', only: [:show]
 
   resources :clicks, only: :create
   resource :profile, controller: 'developers', only: %i[update edit]
@@ -24,4 +25,5 @@ Rails.application.routes.draw do
 
   post '/posts/:slug/like', to: 'posts#like'
   post '/posts/:slug/unlike', to: 'posts#unlike'
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,11 @@ require 'rspec/rails'
 
 ActiveRecord::Migration.maintain_test_schema!
 
+OmniAuth.config.test_mode = true
+OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
+                                                                 :provider => 'google_oauth2',
+                                                                 info: { email: 'til@magmalabs.io' }
+                                                             })
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/requests/sitemap_request_spec.rb
+++ b/spec/requests/sitemap_request_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "Sitemaps", type: :request do
+  describe "show" do
+    context 'GET /sitemap' do
+      it 'returns the xml with all the posts' do
+        post = create(:post)
+        get sitemap_path, format: :xml
+        expect(response.body).to include(post.slug)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Quick Info
It just responds to xml format for now, it follows the simple
sitemap structure that is required by google mastertools

## What does this change?
Adds an endpoint that returns a sitemap.xml

## Why are you changing that?
To speed up indexing time

## Migrations? 👎 

## How do you manually test this?
Go to /sitemap.xml
