### PR TITLE
Add channels and developers to sitemap

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -2,6 +2,7 @@ class SitemapController < ApplicationController
   def show
     @posts = Post.published_and_ordered
     @channels = Channel.with_entries
+    @developers = Developer.with_entries
     respond_to do |format|
       format.xml
     end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,6 +1,7 @@
 class SitemapController < ApplicationController
   def show
     @posts = Post.published_and_ordered
+    @channels = Channel.with_entries
     respond_to do |format|
       format.xml
     end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Channel < ApplicationRecord
+  include WithEntries
+
   validates :name, presence: true
   has_many :posts
 

--- a/app/models/concerns/with_entries.rb
+++ b/app/models/concerns/with_entries.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WithEntries
+  extend ActiveSupport::Concern
+
+  included do
+    scope :with_entries, -> { joins(:posts).distinct }
+  end
+end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Developer < ApplicationRecord
+  include WithEntries
+
   has_many :posts, dependent: :destroy
 
   validates :twitter_handle, length: { maximum: 15 },

--- a/app/views/sitemap/show.xml.builder
+++ b/app/views/sitemap/show.xml.builder
@@ -15,4 +15,10 @@ xml.tag! 'urlset', 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9', 'xm
       xml.lastmod channel.updated_at.strftime('%Y-%m-%d')
     end
   end
+  @developers.each do |developer|
+    xml.url do
+      xml.loc developer_url(developer.username)
+      xml.lastmod developer.updated_at.strftime('%Y-%m-%d')
+    end
+  end
 end

--- a/app/views/sitemap/show.xml.builder
+++ b/app/views/sitemap/show.xml.builder
@@ -9,4 +9,10 @@ xml.tag! 'urlset', 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9', 'xm
       xml.lastmod post.updated_at.strftime('%Y-%m-%d')
     end
   end
+  @channels.each do |channel|
+    xml.url do
+      xml.loc channel_url(channel)
+      xml.lastmod channel.updated_at.strftime('%Y-%m-%d')
+    end
+  end
 end


### PR DESCRIPTION
## Quick Info
Improves a bit sitemap generation

## What does this change?
Adds developers and channels to the sitemap

## Why are you changing that?
So crawlers index more data

## Migrations? 👎 

## How do you manually test this?
Go to /sitemap.xml and should be able to see authors and channels there

