### PR TITLE
Skip drafts in channels and developers in sitemap

### DIFF
--- a/app/models/concerns/with_entries.rb
+++ b/app/models/concerns/with_entries.rb
@@ -4,6 +4,6 @@ module WithEntries
   extend ActiveSupport::Concern
 
   included do
-    scope :with_entries, -> { joins(:posts).distinct }
+    scope :with_entries, -> { joins(:posts).where.not(posts: { published_at: nil}).distinct }
   end
 end


### PR DESCRIPTION
## Quick Info
We should not include blog posts that are in draft to render schema.xml
