### PR TITLE
Schema.org breadcrumb on posts show

### DIFF
--- a/app/serializers/schema_breadcrumbs_serializer.rb
+++ b/app/serializers/schema_breadcrumbs_serializer.rb
@@ -1,0 +1,33 @@
+# frozoen_string_literal: true
+
+class SchemaBreadcrumbsSerializer < SchemaBaseSerializer
+
+  def to_jsonld_data
+    base.to_json
+  end
+
+  def base
+    {
+        '@context': 'http://schema.org',
+        '@type': 'BreadcrumbList',
+        'itemListElement': item_list_element
+    }
+  end
+
+  def item_list_element
+    entries.map.with_index do |entry, index|
+      {
+          '@type': 'ListItem',
+          'position': index + 1,
+          'item': {
+              '@id': entry[:url],
+              'name': entry[:name]
+          }
+      }
+    end
+  end
+
+  def entries
+    raise 'Implement in subclass array of hashes with :url and :name'
+  end
+end

--- a/app/serializers/schema_post_breadcrumbs_serializer.rb
+++ b/app/serializers/schema_post_breadcrumbs_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class SchemaPostBreadcrumbsSerializer < SchemaBreadcrumbsSerializer
+  attr_reader :post
+
+  def initialize(context, post)
+    super(context)
+    @post = post
+  end
+
+  def entries
+    [
+        {
+            url: context.root_url,
+            name: 'MagmaLabs TIL'
+        },
+        {
+            url: context.channel_url(post.channel),
+            name: post.channel_name
+        },
+        {
+            url: context.post_url(post),
+            name: post.title
+        },
+    ]
+  end
+end

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -27,3 +27,6 @@
 %script{ type: 'application/ld+json' }
   = sanitize SchemaBlogpostSerializer.new(self, @post).to_jsonld_data
 
+%script{ type: 'application/ld+json' }
+  = sanitize SchemaPostBreadcrumbsSerializer.new(self, @post).to_jsonld_data
+


### PR DESCRIPTION
## Quick Info
To have better rendering in search engines, we can inject some
breadcrumbs and they will take of the rest, this change
introduces the basic breadcrumb serializer that can be extended
to work on any page, but just posts show for now

## What does this change?
Adds breadcrumbs micro data to posts show

## Why are you changing that?
To have better rendering in search results

## Migrations? nope

## How do you manually test this? wait like a week to see the results on google
