### PR TITLE
Ensure spellcheck with explicit declaration

### DIFF
--- a/app/views/posts/_form.html.haml
+++ b/app/views/posts/_form.html.haml
@@ -1,10 +1,10 @@
 .form_container
   = form_for @post do |f|
-    .field
+    .field{spellcheck: "true"}
       = f.label :title
       = f.error_message_on :title
       = f.text_field :title, placeholder: 'Enter title...'
-    .field
+    .field{spellcheck: "true"}
       = f.label :body
       = f.error_message_on :body
       #editor


### PR DESCRIPTION
## Quick Info
Try to force browsers to enable spellcheck in the post form fields

## What does this change?
Explicitly sets spellcheck to true on form 

## Why are you changing that?
To help create better TILs and a better image for magma

## Migrations?
no

## How do you manually test this?
Make some spelling errors

## Screenshots
