### PR TITLE
Change navbar dev name link to display users posts

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -12,6 +12,10 @@ class Developer < ApplicationRecord
     ['Text Field', 'Ace (w/ Vim)', 'Ace'].freeze
   end
 
+  def to_param
+    username
+  end
+
   validates :editor, inclusion: {
       in: editor_options,
       message: '%<value> is not a valid editor'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     - if logged_in?
       %nav.admin_panel
         %ul
-          %li= link_to current_developer.username, current_developer
+          %li= link_to current_developer.username, developer_path(current_developer.username)
           %li= link_to "Log Out", signout_path, method: :delete
           %li= link_to "Create Post", new_post_path
           %li= link_to "Drafts", drafts_path

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     - if logged_in?
       %nav.admin_panel
         %ul
-          %li= link_to current_developer.username, developer_path(current_developer.username)
+          %li= link_to current_developer.username, developer_path(current_developer)
           %li= link_to "Log Out", signout_path, method: :delete
           %li= link_to "Create Post", new_post_path
           %li= link_to "Drafts", drafts_path

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -6,7 +6,7 @@
       = find_and_preserve markdown_render post.body
       %p.footer
         Learned by
-        = link_to post.developer_username, developer_path(post.developer_username)
+        = link_to post.developer_username, developer_path(post.developer)
         - unless post.published?
           (draft)
         on


### PR DESCRIPTION
- Correct path to display current devs post when clicking
  on the name in the navbar fixes https://github.com/magma-labs/til/issues/30

## Quick Info
Correctly display current_developer's posts

## What does this change?
Changes the route in the name link

## Why are you changing that?
Liunk was broken

## Migrations?
no

## How do you manually test this?
Click on your name! 

## Screenshots
