### PR TITLE
fix/add img size mobile

### DIFF
--- a/app/assets/stylesheets/_components.sass
+++ b/app/assets/stylesheets/_components.sass
@@ -52,7 +52,7 @@ nav.pagination
   justify-content: center
   +mobile
     display: block
-    margin: 0
+    margin: 1rem 0
     padding: 0 1rem
   &.draft
     opacity: .8
@@ -330,7 +330,16 @@ form
   img
     width: 100%
     object-fit: contain
-
+  +mobile
+    .regular_image
+      display: none
+    .mobile_image
+      display: block
+  +tablet
+    .regular_image
+      display: block
+    .mobile_image
+      display: none
 
 .more-info
   margin: 3vw auto

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -39,4 +39,5 @@
 - if post.id.to_i.odd? || action_name == 'show'
   - if ad = Ad.random
     .magma_container
-      = link_to(image_tag(ad.image_url), clicks_path(id: ad), method: :post)
+      = link_to(image_tag(ad.image_url, class: 'regular_image'), clicks_path(id: ad), method: :post)
+      = link_to(image_tag(ad.mobile_image_url, class: 'mobile_image'), clicks_path(id: ad), method: :post)

--- a/db/migrate/20210224230319_add_smal_image_url_to_ads.rb
+++ b/db/migrate/20210224230319_add_smal_image_url_to_ads.rb
@@ -1,0 +1,5 @@
+class AddSmalImageUrlToAds < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ads, :mobile_image_url, :string, default: '', null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -30,7 +30,8 @@ CREATE TABLE public.ads (
     link_url character varying NOT NULL,
     clicks integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    mobile_image_url character varying DEFAULT ''::character varying NOT NULL
 );
 
 
@@ -406,6 +407,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20160708201736'),
 ('20210202151545'),
 ('20210206213709'),
-('20210212181919');
+('20210212181919'),
+('20210224230319');
 
 

--- a/vendor/assets/stylesheets/mercury.scss
+++ b/vendor/assets/stylesheets/mercury.scss
@@ -25,7 +25,7 @@ $svg-rendering: 'geometricPrecision' !default;
 }
 
 @mixin tablet {
-  @include max-width($site-width-mid) {
+  @include min-width($site-width-narrow) {
     @content;
   }
 }


### PR DESCRIPTION
## Quick Info
 Display diferent ad img src for mobile and for tablet and up

## What does this change?

- Fix seeds
- Add small_image_url to Ad
- Allow a litle space between posts
- Use diferent image sizes for ad
- Change breakpoints for mobile first

## Why are you changing that?
 For better ad usage

## Migrations?
Yes

## How do you manually test this?
open the rails console, an do  
```
ad = Ad.first
ad.mobile_img_url = 'https://www.magmalabs.io/packs/media/images/magma-logo-e56e4fa7dc892ffb0d967906890b3ecd.svg'
ad.save
```

then run `rails s`, press f12, and chose different viewports

## Screenshots
