### PR TITLE
Improving GA Tracking

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,7 +16,7 @@
       = link_to image_tag('logo.png'), root_path, title: 'TIL MagmaLabs', class: 'ml'
       = link_to root_url do
         %h1 TODAY I LEARNED
-      = render 'shared/google_analytics'
+      = render 'shared/google_analytics' unless logged_in?
 
     = render 'shared/flash'
 

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -1,4 +1,4 @@
-%article.post{ :class => unless post.published? then 'draft' end }
+%article.post{ :class => unless post.published? then 'draft' end, data: { title: post.title, url: post_url(post), path: post_path(post) } }
   %section
     .post__content.copy
       %h1= link_to post.title, post

--- a/app/views/shared/_google_analytics.html.haml
+++ b/app/views/shared/_google_analytics.html.haml
@@ -7,3 +7,28 @@
     gtag('js', new Date());
 
     gtag('config', '#{ENV['GOOGLE_ANALYTICS_ID']}');
+
+  :javascript
+    document.addEventListener("DOMContentLoaded", function() {
+      var posts = [].slice.call(document.querySelectorAll("#home .post"));
+
+      if ("IntersectionObserver" in window) {
+        let postObserver = new IntersectionObserver(function(entries, observer) {
+          entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+              let post = entry.target;
+              gtag('event', 'page_view', {
+                page_title: post.dataset.title,
+                page_location: post.dataset.url,
+                page_path: post.dataset.path
+              })
+              postObserver.unobserve(post);
+            }
+          });
+        });
+
+        posts.forEach(function(post) {
+          postObserver.observe(post);
+        });
+      }
+    });


### PR DESCRIPTION
## Quick Info
* Skip rendering GA code if user is logged in, it means it's internal traffic
  it will stop sending page views from management section
* Adds tracking of posts visited in homepage, if user keeps scrolling, it
  detects what post is at and sends a visit to it, helpful when visitors
  only keep scrolling

## What does this change?
Improves GA implementation

## Why are you changing that?
GA was receiving page visits from post/new, post/edit, drafts, etc, data that generates no value
Homepage renders pretty much most of the posts, or at least, in a paginated way, users do not need to go to post detail page to read the whole content, so, I implemented a way to track what posts are being read anyway in homepage
