### PR TITLE
Fix slack integration

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -11,6 +11,7 @@ development: &default
   twitter_consumer_secret:
   update_twitter_with_post: "false"
   SENDGRID_API_KEY:
+  HOST_NAME: 'http://localhost:3000'
 
 test:
   <<: *default
@@ -28,3 +29,4 @@ production:
   twitter_consumer_secret:
   update_twitter_with_post: "false"
   SENDGRID_API_KEY:
+  HOST_NAME: 'https://til.magmalabs.io'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,4 +71,6 @@ Rails.application.configure do
     Bullet.rails_logger = true
     Bullet.add_footer = true
   end
+
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST_NAME', 'http://localhost:3000')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,4 +96,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST_NAME', 'https://til.magmalabs.io')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,4 +38,6 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST_NAME', 'https://til.magmalabs.io')
 end


### PR DESCRIPTION
## Quick Info
Adds default host url to application environments Closes #46 

## What does this change?
- Sets default host url for environments using HOST_NAME or default url for each environment.

## Why are you changing that?
Because slack notifications are not working and are blocking new til posts due to missing host url.

## Migrations?
No

## How do you manually test this?
Creating and publishing new posts.

## Screenshots
![image](https://user-images.githubusercontent.com/12720067/210871887-20389725-2dd0-453c-bd0a-243d91c010f2.png)
