### PR TITLE
Fix color of category select in order to be visible

### DIFF
--- a/app/assets/stylesheets/_components.sass
+++ b/app/assets/stylesheets/_components.sass
@@ -200,6 +200,8 @@ form
       margin-bottom: 1.5em
       input[type='checkbox']
         margin-right: 1rem
+  #post_channel_id
+    color: black
   dl
     dt
       +clearfix

--- a/app/assets/stylesheets/_components.sass
+++ b/app/assets/stylesheets/_components.sass
@@ -200,7 +200,7 @@ form
       margin-bottom: 1.5em
       input[type='checkbox']
         margin-right: 1rem
-  #post_channel_id
+  #post_channel_id, #developer_editor
     color: black
   dl
     dt


### PR DESCRIPTION
## Quick Info
There is a visual error in our app "Today I Learned" when creating a new post. When you click on the "create a post" link and navigate to the blog creator page (/new/post), the selected channel category does not show visually because it is using a white color font.  Closes #45 

## What does this change?
Update color of font to be black

## Why are you changing that?
Because the font is not readable to the users.

## Migrations?
No

## How do you manually test this?
Manually visiting the form

## Screenshots
![image](https://user-images.githubusercontent.com/12720067/211071986-87c43ef0-451a-489a-99af-78dbbeed9e61.png)
