### PR TITLE
Make header logo and title sticky at top

### DIFF
--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -12,6 +12,10 @@ body
   font-size: 1.6em
 
 header
+  position: fixed
+  left: 0
+  right: 0
+  top: 0
   margin-top: 40px
   margin-bottom: 15px
   text-align: center
@@ -262,3 +266,6 @@ header.page_head
     &.error
       border-color: $error
       color: $error
+
+#home
+  margin-top: 27vh


### PR DESCRIPTION
## Quick Info
As a user, I would like the ability to scroll through posts on the Today I Learned web app without losing sight of the header. It would be great if the header became "sticky" and remained at the top of the screen as I scroll through the posts. This would make it easier for me to navigate the website and access the different sections of the site. Closes #49

## What does this change?
Makes the header remains visible and "sticks" to the top of the screen as you scroll through the posts

## Migrations?
No

## How do you manually test this?
Visually on mobile and desktop

## Screenshots
![image](https://user-images.githubusercontent.com/12720067/212978863-8c8c9ae2-0b5e-402b-8a7a-b5def2dba51c.png)
![image](https://user-images.githubusercontent.com/12720067/212978918-ac6bc268-85da-45fd-b32c-e3462aa267c3.png)
