### PR TITLE
Update/posts footer

### DIFF
--- a/app/assets/stylesheets/_components.sass
+++ b/app/assets/stylesheets/_components.sass
@@ -82,10 +82,14 @@ nav.pagination
         transition: color .1s
         &:hover
           color: $yellow
-  p.footer
-    font-size: 80%
-    font-style: italic
-    margin: 0
+  .footer
+    .details-container
+      display: flex
+      justify-content: space-between
+    .left
+      order: 1
+    .right
+      order: 2
 
   aside
     ul

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -37,7 +37,7 @@ header
     top: 0
 
 main
-  margin-top: 27vh
+  margin-top: 27rem
 
 .site_nav
   position: fixed

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -22,7 +22,7 @@
               %span{title: post.created_at}
                 = post.created_at.strftime("%b %-d, %Y")
           %div.right
-            = link_to "Read our blog", "https://blog.magmalabs.io/?utm_source=til&utm_medium=header&utm_campaign=til"
+            = link_to "Discover our latest blog posts", "https://blog.magmalabs.io/?utm_source=til&utm_medium=header&utm_campaign=til"
     %aside
       %ul
         %li

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -8,17 +8,21 @@
       %h1= link_to post.title, post
 
       = find_and_preserve markdown_render post.body
-      %p.footer
+      %div.footer
         - if content_for?(:social)
           %p.post__social= content_for :social
-        %p
-        Learned by
-        = link_to post.developer_username, developer_path(post.developer)
-        - unless post.published?
-          (draft)
-        on
-        %span{title: post.created_at}
-          = post.created_at.strftime("%b %-d, %Y")
+        %div.details-container
+          %div.left
+            %p
+              Learned by
+              = link_to post.developer_username, developer_path(post.developer)
+              - unless post.published?
+                (draft)
+              on
+              %span{title: post.created_at}
+                = post.created_at.strftime("%b %-d, %Y")
+          %div.right
+            = link_to "Read our blog", "https://blog.magmalabs.io/?utm_source=til&utm_medium=header&utm_campaign=til"
     %aside
       %ul
         %li


### PR DESCRIPTION
## Quick Info
Adds magmalabs blog link.

## What does this change?
Adds magmalabs blog link to the posts footer.

## Why are you changing that?
We have a new campaign to redirect users from til to magmlabs blog.

## Migrations?
No

## How do you manually test this?
Tested visually in desktop and mobile.

## Screenshots
![image](https://user-images.githubusercontent.com/12720067/229580424-a78dd411-7a43-4135-974d-5f44407ca5c0.png)
