### PR TITLE
Add `ai` record to channels

### DIFF
--- a/db/seeds/common/channels.rb
+++ b/db/seeds/common/channels.rb
@@ -18,7 +18,8 @@ channels = [
     { name: 'testing', twitter_hashtag: 'testing' },
     { name: 'vim', twitter_hashtag: 'vim' },
     { name: 'vue', twitter_hashtag: 'vue' },
-    { name: 'workflow', twitter_hashtag: 'workflow' }
+    { name: 'workflow', twitter_hashtag: 'workflow' },
+    { name: 'ai', twitter_hashtag: 'ai' }
 ]
 
 channels.each do |channel|


### PR DESCRIPTION
## Quick Info

We want to add an `AI` record to the channels table.

This record will be used to represent the `Artificial Intelligence`
channel.

After adding the record, we will be able to select this channel during
the post-creation process.
