### PR TITLE
Remove the ad section

### DIFF
--- a/app/assets/stylesheets/_components.sass
+++ b/app/assets/stylesheets/_components.sass
@@ -333,26 +333,6 @@ form
     padding: 1em 0 .1em 3vw
     font-size: .9em
 
-.magma_container
-  position: relative
-  margin: 1rem auto
-  padding: 0 1rem
-  // This max width should change when we haver art for different screen sizes
-  max-width: 728px
-  img
-    width: 100%
-    object-fit: contain
-  +mobile
-    .regular_image
-      display: none
-    .mobile_image
-      display: block
-  +tablet
-    .regular_image
-      display: block
-    .mobile_image
-      display: none
-      
 .more-info
   margin: 3vw auto
   text-align: center

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -43,10 +43,3 @@
               %span.post__like-label likes
 
 = content_for :post_nav
-
-- if post.id.to_i.odd? || action_name == 'show'
-  - if ad = Ad.random
-    .magma_container
-      = link_to(image_tag(ad.image_url, class: 'regular_image',  alt: '', width: '728', height: '90'), clicks_path(id: ad), aria: { label: 'Github code review on demand for you' }, method: :post)
-      - if ad.mobile_image_url.present?
-        = link_to(image_tag(ad.mobile_image_url, class: 'mobile_image', alt: ''), clicks_path(id: ad), aria: { label: 'Github code review on demand for you' }, method: :post)


### PR DESCRIPTION
## Quick Info

We need to remove the ad section located underneath the post section
because the image appears broken.

I've noticed that the image source is from Dropbox, so it's likely that
we've lost access to that content or the image has been removed.

I need to confirm whether this removal is temporary or permanent.

## Screenshots

|Before|After|
|---|---|
|<img width="1013" alt="image" src="https://github.com/magma-labs/til/assets/10084099/329a7a0e-6c70-4650-a03b-3cd92f0bd038">|<img width="1013" alt="image" src="https://github.com/magma-labs/til/assets/10084099/67594488-6a76-4f8b-9691-df1693201d7d">|