### PR TITLE
Add heroku yml file

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## Quick Info

I attempted to make a manual deployment using the Heroku CLI and noticed this error:

<img width="1213" alt="image" src="https://github.com/magma-labs/til/assets/10084099/6bd859ef-b5e1-4c96-bfc2-d15b9d766671">

It seems we need this Heroku config file, which indicates how to build the app, specifies add-ons for the app’s needs, and also takes advantage of the review apps.

All of this seems to be very new, as [the official docs](https://devcenter.heroku.com/articles/build-docker-images-heroku-yml) have an April 2024 date (last updated April 25, 2024).

After adding this Heroku file and trying to deploy it again, It was successful. You can review it here on [staging](https://magma-til-staging.herokuapp.com/posts/new).