### PR TITLE
Specify which railties we want to require

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -19,6 +19,6 @@ module MarkdownHelper
   end
 
   def markdown_render(md)
-    sanitize markdown.render md
+    sanitize find_and_preserve markdown.render md
   end
 end

--- a/app/serializers/schema_blogpost_serializer.rb
+++ b/app/serializers/schema_blogpost_serializer.rb
@@ -21,7 +21,7 @@ class SchemaBlogpostSerializer < SchemaBaseSerializer
         'datePublished': entry.created_at.strftime('%Y-%m-%d'),
         'dateModified': entry.updated_at.strftime('%Y-%m-%d'),
         'articleBody': entry.body,
-        'image': context.image_url('logo'),
+        'image': context.image_url('logo.png'),
         'inLanguage': 'en-US',
         'copyrightYear': entry.created_at.year,
         'keywords': [entry.channel_name, 'MagmaLabs TIL', 'BlogPost', 'Today I Learned'],
@@ -56,7 +56,7 @@ class SchemaBlogpostSerializer < SchemaBaseSerializer
             'url': 'https://www.magmalabs.io',
             'logo': {
                 '@type': 'ImageObject',
-                'url': context.image_url('magma-logo')
+                'url': context.image_url('magma-logo.svg')
             }
         }
     }

--- a/app/serializers/schema_organization_serializer.rb
+++ b/app/serializers/schema_organization_serializer.rb
@@ -8,7 +8,7 @@ class SchemaOrganizationSerializer < SchemaBaseSerializer
         '@context': 'http://schema.org',
         '@type': 'Organization',
         'url': context.root_url,
-        'logo': context.image_url('magma-logo')
+        'logo': context.image_url('magma-logo.svg')
     }.merge(same_as).to_json
   end
 

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -7,7 +7,7 @@
     .post__content.copy
       %h1= link_to post.title, post
 
-      = find_and_preserve markdown_render post.body
+      = markdown_render post.body
       %div.footer
         - if content_for?(:social)
           %p.post__social= content_for :social

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,17 @@
 
 require_relative 'boot'
 
-require 'rails/all'
+%w(
+  active_record/railtie
+  action_controller/railtie
+  action_view/railtie
+  action_mailer/railtie
+).each do |railtie|
+  begin # rubocop:disable Style/RedundantBegin
+    require railtie
+  rescue LoadError
+  end
+end
 
 Bundler.require(*Rails.groups)
 


### PR DESCRIPTION
## Quick Info
We are being explicit about which railties we want to require in our
application. This is to be able to deploy our application successfully.

Also, we fixed an issue in the body of the posts when rendered and 
addressed a deprecation warning about some assets not being 
present in the asset pipeline. The latter occurs during builds.